### PR TITLE
Improve viewer pages

### DIFF
--- a/viewer.html
+++ b/viewer.html
@@ -35,28 +35,33 @@
     var folder = "A";
     if (getQueryVariable("id") != -1) id = getQueryVariable("id");
     if (getQueryVariable("folder") != -1) folder = getQueryVariable("folder");
-    var xmlhttp = new XMLHttpRequest();
-    var url = "/TMUWSI/b.json";
-    var request = new XMLHttpRequest();
-    request.open("GET", url, false); // `false` makes the request synchronous
-    request.send(null);
-    if (request.status == 200) {
-        jsonparse(JSON.parse(request.responseText));
-    } else {
-        console.log("help");
-    }
-    console.log(id + "/" + width + "/" + height);
-    for (var i = 0; Math.pow(2, i) < Math.max(height, width); i++) maxlev++;
-    maxlev--;
-    var viewer = OpenSeadragon({
-        id: "seadragon-viewer",
-        prefixUrl: "/TMUWSI/openseadragon/images/",
-        defaultZoomLevel: 0.25,
-        imageLoaderlimit: 1,
-        debugMode: true,
-        showNavigator: true,
-        //minZoomImageRatio:0,
-        tileSources: {
+    const url = "/TMUWSI/b.json";
+    let viewer;
+
+    (async () => {
+        try {
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(response.statusText);
+            jsonparse(await response.json());
+            initViewer();
+        } catch (err) {
+            console.log("Error loading JSON", err);
+        }
+    })();
+
+    function initViewer() {
+        console.log(id + "/" + width + "/" + height);
+        for (var i = 0; Math.pow(2, i) < Math.max(height, width); i++) maxlev++;
+        maxlev--;
+        viewer = OpenSeadragon({
+            id: "seadragon-viewer",
+            prefixUrl: "/TMUWSI/openseadragon/images/",
+            defaultZoomLevel: 0.25,
+            imageLoaderlimit: 1,
+            debugMode: true,
+            showNavigator: true,
+            //minZoomImageRatio:0,
+            tileSources: {
             height: height,
             width: width,
             tileSize: 256,
@@ -70,8 +75,8 @@
                 else twidth = (x + 1) * tileSize;
                 if ((y + 1) * tileSize > height / a) theight = Math.round(height / a);
                 else theight = (y + 1) * tileSize;
-                //console.log("http://pbel2.tmu.edu.tw:88/anatomy/A/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
-                return ("http://pbel2.tmu.edu.tw:88/anatomy/" + folder + "/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                //console.log("https://pbel2.tmu.edu.tw:88/anatomy/A/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                return ("https://pbel2.tmu.edu.tw:88/anatomy/" + folder + "/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
                 /*console.log(
                   x + "/" + y + "/" + level + "/" + a + "/" + twidth + "/" + theight
                 );*/
@@ -79,6 +84,7 @@
         }
     });
 
+}
     function jsonparse(data) {
         for (var i = 0; i < 233; i++) {
             if (data[i].id == id) {

--- a/viewer2.html
+++ b/viewer2.html
@@ -35,20 +35,25 @@
     var maxlev = 0;
     var folder = "A";
     if (getQueryVariable("id") != -1) id = getQueryVariable("id");
-    var xmlhttp = new XMLHttpRequest();
-    var url = "/TMUWSI/d.json";
-    var request = new XMLHttpRequest();
-    request.open("GET", url, false); // `false` makes the request synchronous
-    request.send(null);
-    if (request.status == 200) {
-        jsonparse(JSON.parse(request.responseText));
-    } else {
-        console.log("help");
-    }
-    console.log(id + "/" + width + "/" + height);
-    for (var i = 0; Math.pow(2, i) < Math.max(height, width); i++) maxlev++;
-    maxlev--;
-    var viewer = OpenSeadragon({
+    const url = "/TMUWSI/d.json";
+    let viewer;
+
+    (async () => {
+        try {
+            const response = await fetch(url);
+            if (!response.ok) throw new Error(response.statusText);
+            jsonparse(await response.json());
+            initViewer();
+        } catch (err) {
+            console.log("Error loading JSON", err);
+        }
+    })();
+
+    function initViewer() {
+        console.log(id + "/" + width + "/" + height);
+        for (var i = 0; Math.pow(2, i) < Math.max(height, width); i++) maxlev++;
+        maxlev--;
+    viewer = OpenSeadragon({
         id: "seadragon-viewer",
         prefixUrl: "/TMUWSI/openseadragon/images/",
         defaultZoomLevel: 0.25,
@@ -70,13 +75,14 @@
                 else twidth = (x + 1) * tileSize;
                 if ((y + 1) * tileSize > height / a) theight = Math.round(height / a);
                 else theight = (y + 1) * tileSize;
-                return ("http://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
-                //console.log("http://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                return ("https://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                //console.log("https://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
 
             }
         }
     });
 
+}
     function jsonparse(dataa) {
         /*
         for (var i = 0; i < 233; i++) {


### PR DESCRIPTION
## Summary
- load metadata using fetch instead of deprecated synchronous `XMLHttpRequest`
- initialise OpenSeadragon after async load completes
- request image tiles over HTTPS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68798d51b54483279418572b80963cc9