### PR TITLE
Fix tile viewer URL to use HTTP

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <title>TMUWSI</title>
-    <link type="image/png" sizes="32x32" rel="icon" href="/TMUWSI/icons8-cat-pot-32.png">
+    <link type="image/png" sizes="32x32" rel="icon" href="icons8-cat-pot-32.png">
   </head>
   
   <body>
     <h2>TMUWSI</h2>
-  <input type="button" value="病理學" onclick="location.href='/TMUWSI/index2.html'">
+  <input type="button" value="病理學" onclick="location.href='index2.html'">
   <style>
     table,
     th,
@@ -22,7 +22,7 @@
     <p id="demo"></p>
     <script>
       var xmlhttp = new XMLHttpRequest();
-      var url = "/TMUWSI/a.json";
+      var url = "a.json";
 
       var _table_ = document.createElement("table"),
         _tr_ = document.createElement("tr"),
@@ -45,7 +45,7 @@
               var linkt = document.createElement("a");
               linkt.setAttribute(
                 "href",
-                "/TMUWSI/viewer.html?id=" +
+                "viewer.html?id=" +
                   arr[i][columns[5]] +
                   "&folder=" +
                   arr[i][columns[4]]

--- a/index2.html
+++ b/index2.html
@@ -2,12 +2,12 @@
 <html>
   <head>
     <title>TMUWSI</title>
-    <link type="image/png" sizes="32x32" rel="icon" href="/TMUWSI/icons8-cat-pot-32.png">
+    <link type="image/png" sizes="32x32" rel="icon" href="icons8-cat-pot-32.png">
   </head>
   
   <body>
     <h2>TMUWSI</h2>
-    <input type="button" value="一般組織學" onclick="location.href='/TMUWSI/index.html'">
+    <input type="button" value="一般組織學" onclick="location.href='index.html'">
     <style>
     table,
     th,
@@ -22,7 +22,7 @@
     <p id="demo"></p>
     <script>
       var xmlhttp = new XMLHttpRequest();
-      var url = "/TMUWSI/c.json";
+      var url = "c.json";
 
       var _table_ = document.createElement("table"),
         _tr_ = document.createElement("tr"),
@@ -43,7 +43,7 @@
               var linkt = document.createElement("a");
               linkt.setAttribute(
                 "href",
-                "/TMUWSI/viewer2.html?id=" +
+                "viewer2.html?id=" +
                   arr[i][columns[0]]
               );
               linkt.appendChild(textt);

--- a/viewer.html
+++ b/viewer.html
@@ -2,17 +2,17 @@
 <html>
   <head>
     <title>TMUWSI</title>
-    <link type="image/png" sizes="32x32" rel="icon" href="/TMUWSI/icons8-cat-pot-32.png">
+    <link type="image/png" sizes="32x32" rel="icon" href="icons8-cat-pot-32.png">
   </head>
   
   <body>
-<input type="button" value="返回列表" onclick="location.href='/TMUWSI/index.html'">
+<input type="button" value="返回列表" onclick="location.href='index.html'">
 <form name="form" id="form"> quality: <input type="text" name="quality" id="quality" value="S" />debug: <input type="text" name="debug" id="debug" value="false" />
     <input type="button" name="submit" value="更新" onclick="processFormData();" />
 </form>
 <p id="demo"></p>
 <div id="seadragon-viewer" style="width: 100%; height: 100%;"></div>
-<script src="/TMUWSI/openseadragon/openseadragon.min.js"></script>
+<script src="openseadragon/openseadragon.min.js"></script>
 <script>
     function getQueryVariable(variable) {
         var query = window.location.search.substring(1);
@@ -35,7 +35,7 @@
     var folder = "A";
     if (getQueryVariable("id") != -1) id = getQueryVariable("id");
     if (getQueryVariable("folder") != -1) folder = getQueryVariable("folder");
-    const url = "/TMUWSI/b.json";
+    const url = "b.json";
     let viewer;
 
     (async () => {
@@ -55,7 +55,7 @@
         maxlev--;
         viewer = OpenSeadragon({
             id: "seadragon-viewer",
-            prefixUrl: "/TMUWSI/openseadragon/images/",
+            prefixUrl: "openseadragon/images/",
             defaultZoomLevel: 0.25,
             imageLoaderlimit: 1,
             debugMode: true,
@@ -75,8 +75,8 @@
                 else twidth = (x + 1) * tileSize;
                 if ((y + 1) * tileSize > height / a) theight = Math.round(height / a);
                 else theight = (y + 1) * tileSize;
-                //console.log("https://pbel2.tmu.edu.tw:88/anatomy/A/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
-                return ("https://pbel2.tmu.edu.tw:88/anatomy/" + folder + "/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                //console.log("http://pbel2.tmu.edu.tw:88/anatomy/A/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                return ("http://pbel2.tmu.edu.tw:88/anatomy/" + folder + "/" + id + "?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
                 /*console.log(
                   x + "/" + y + "/" + level + "/" + a + "/" + twidth + "/" + theight
                 );*/

--- a/viewer2.html
+++ b/viewer2.html
@@ -3,17 +3,17 @@
 <html>
   <head>
     <title>TMUWSI</title>
-    <link type="image/png" sizes="32x32" rel="icon" href="/TMUWSI/icons8-cat-pot-32.png">
+    <link type="image/png" sizes="32x32" rel="icon" href="icons8-cat-pot-32.png">
   </head>
   
   <body>
-<input type="button" value="返回列表" onclick="location.href='/TMUWSI/index2.html'">
+<input type="button" value="返回列表" onclick="location.href='index2.html'">
 <form name="form" id="form"> quality: <input type="text" name="quality" id="quality" value="S" />debug: <input type="text" name="debug" id="debug" value="false" />
     <input type="button" name="submit" value="更新" onclick="processFormData();" />
 </form>
 <p id="demo"></p>
 <div id="seadragon-viewer" style="width: 100%; height: 100%;"></div>
-<script src="/TMUWSI/openseadragon/openseadragon.min.js"></script>
+<script src="openseadragon/openseadragon.min.js"></script>
 <script>
     function getQueryVariable(variable) {
         var query = window.location.search.substring(1);
@@ -35,7 +35,7 @@
     var maxlev = 0;
     var folder = "A";
     if (getQueryVariable("id") != -1) id = getQueryVariable("id");
-    const url = "/TMUWSI/d.json";
+    const url = "d.json";
     let viewer;
 
     (async () => {
@@ -55,7 +55,7 @@
         maxlev--;
     viewer = OpenSeadragon({
         id: "seadragon-viewer",
-        prefixUrl: "/TMUWSI/openseadragon/images/",
+        prefixUrl: "openseadragon/images/",
         defaultZoomLevel: 0.25,
         imageLoaderlimit: 1,
         debugMode: true,
@@ -75,8 +75,8 @@
                 else twidth = (x + 1) * tileSize;
                 if ((y + 1) * tileSize > height / a) theight = Math.round(height / a);
                 else theight = (y + 1) * tileSize;
-                return ("https://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
-                //console.log("https://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                return ("http://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
+                //console.log("http://pbel2.tmu.edu.tw:88/Teaching%20Slide/" + id + ".svs?" + x * tileSize + "+" + y * tileSize + "+" + twidth + "+" + theight + "+" + a + "+80+" + quality);
 
             }
         }


### PR DESCRIPTION
## Summary
- switch tile URL schemes back to HTTP so old slide images load

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68799238d20883279e1a0806fd9e8f63